### PR TITLE
Feature/update index main project

### DIFF
--- a/projects/lib-magnetar-quill/src/lib/services/keyboard-shortcut.service.spec.ts
+++ b/projects/lib-magnetar-quill/src/lib/services/keyboard-shortcut.service.spec.ts
@@ -120,7 +120,9 @@ describe('KeyboardShortcutService', () => {
       (service as any).fmt = mockFormattingService;
   });
 
-
+  // TODO:
+  // CRITICAL!:
+  /*The tests in the Target Element Filtering suite check for behavior that seems to be disabled in KeyboardShortcutService. Specifically, the service has a commented-out return statement that is supposed to prevent shortcuts from firing on INPUT, TEXTAREA, and SELECT elements. Because this logic is disabled, these tests will likely fail. Please either enable the logic in the service or adjust the tests to reflect the intended behavior.*/
   // --- Target Element Filtering ---
   describe('Target Element Filtering', () => {
     it('should ignore shortcuts when target is an INPUT element', () => {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a critical TODO note in the KeyboardShortcutService spec highlighting that the target-element filtering logic (to prevent shortcuts on INPUT/TEXTAREA/SELECT) is currently disabled, which may cause failing tests, and requesting to enable the logic or adjust tests.

### Why are these changes being made?

Document an unresolved issue and intended action: the service has a disabled return path for input-like targets, which likely breaks related tests; this note calls out the need to either re-enable the logic or align tests accordingly.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

## Summary by Sourcery

Documentation:
- Insert a note in Target Element Filtering tests warning that disabled filtering logic for INPUT/TEXTAREA/SELECT elements may break tests and needs to be reactivated or tests updated.