### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snorkell-auto-documentation.yml
+++ b/.github/workflows/snorkell-auto-documentation.yml
@@ -7,6 +7,10 @@ on:
     branches: ["master"]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   Documentation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/scherenhaenden/MagnetarQuill/security/code-scanning/3](https://github.com/scherenhaenden/MagnetarQuill/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default, while granting only what this automation needs.  
Best fix here: define permissions at the workflow root (applies to all jobs) right after `on:` and before `jobs:`.

For this workflow, the action is described as generating documentation changes and creating a PR, so a practical minimal set is:

- `contents: write` (commit/push branch updates)
- `pull-requests: write` (open/update PRs)

No imports, methods, or extra definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Add an explicit permissions block to restrict GITHUB_TOKEN to contents and pull-requests write access in the snorkell auto-documentation workflow.